### PR TITLE
Update install command add deps

### DIFF
--- a/src/Commands/LaravelInitCommand.php
+++ b/src/Commands/LaravelInitCommand.php
@@ -47,6 +47,7 @@ class LaravelInitCommand extends Command
         $this->runShellCommand("php artisan vendor:publish --tag=cloudflare-cache-config {$force}");
         $this->runShellCommand("php artisan vendor:publish --tag=sitemap-config {$force}");
         $this->runShellCommand("php artisan vendor:publish --tag=navigation-config {$force}");
+        $this->runShellCommand("php artisan vendor:publish --tag=navigation-logo {$force}");
         $this->runShellCommand("php artisan vendor:publish --tag=forms-config {$force}");
 
         $this->runShellCommand('php artisan vite:install');

--- a/src/Commands/LaravelInitCommand.php
+++ b/src/Commands/LaravelInitCommand.php
@@ -20,6 +20,7 @@ class LaravelInitCommand extends Command
     public function handle()
     {
         $packages = [
+            'fuelviews/laravel-layout-wrapper' => '^0.0',
             'fuelviews/laravel-cloudflare-cache' => '^0.0',
             'fuelviews/laravel-robots-txt' => '^0.0',
             'fuelviews/laravel-sitemap' => '^0.0',


### PR DESCRIPTION
Adds a new vendor publish command in the LaravelInitCommand.php file. Specifically, it includes the command "php artisan vendor:publish --tag=navigation-logo {$force}". This addition ensures that the navigation logo configuration is properly published when running the Laravel initialization command.

This update enhances the functionality of the Laravel project by allowing for the publication of the navigation logo configuration, which is essential for the project's navigation features.