### PR TITLE
Fix force bug

### DIFF
--- a/src/Commands/LaravelInitCommand.php
+++ b/src/Commands/LaravelInitCommand.php
@@ -44,7 +44,7 @@ class LaravelInitCommand extends Command
         $this->runShellCommand("php artisan vendor:publish --tag=navigation-config {$force}");
         $this->runShellCommand("php artisan vendor:publish --tag=navigation-logo {$force}");
         $this->runShellCommand("php artisan vendor:publish --tag=forms-config {$force}");
-        $this->runShellCommand("php artisan vendor:publish --provider=Spatie\MediaLibrary\MediaLibraryServiceProvider' --tag=medialibrary-migrations {$force}");
+        $this->runShellCommand("php artisan vendor:publish --provider=Spatie\MediaLibrary\MediaLibraryServiceProvider' --tag=medialibrary-migrations");
 
         $this->runShellCommand("php artisan vite:install {$force}");
         $this->runShellCommand("php artisan tailwindcss:install {$force}");

--- a/src/Commands/LaravelInitCommand.php
+++ b/src/Commands/LaravelInitCommand.php
@@ -44,7 +44,7 @@ class LaravelInitCommand extends Command
         $this->runShellCommand("php artisan vendor:publish --tag=navigation-config {$force}");
         $this->runShellCommand("php artisan vendor:publish --tag=navigation-logo {$force}");
         $this->runShellCommand("php artisan vendor:publish --tag=forms-config {$force}");
-        $this->runShellCommand("php artisan vendor:publish --provider=Spatie\MediaLibrary\MediaLibraryServiceProvider' --tag=medialibrary-migrations");
+        $this->runShellCommand("php artisan vendor:publish --provider='Spatie\MediaLibrary\MediaLibraryServiceProvider' --tag=medialibrary-migrations");
 
         $this->runShellCommand("php artisan vite:install {$force}");
         $this->runShellCommand("php artisan tailwindcss:install {$force}");

--- a/src/LaravelInit.php
+++ b/src/LaravelInit.php
@@ -2,6 +2,4 @@
 
 namespace Fuelviews\Init;
 
-class LaravelInit
-{
-}
+class LaravelInit {}


### PR DESCRIPTION
Fixes a bug related to the force option in the `LaravelInitCommand.php` file. The issue was caused by a missing single quote in the `vendor:publish` command for the `medialibrary-migrations` tag.
The corrected command now includes the necessary single quotes around the provider name, ensuring that the command is executed correctly.

Additionally, in the `LaravelInit.php` file, unnecessary code related to the `LaravelInit` class has been removed, improving code cleanliness and maintainability.

This fix resolves the force bug and ensures that the `vendor:publish` command works as expected for the `medialibrary-migrations` tag.