### PR TITLE
Fix install bugs

### DIFF
--- a/src/Commands/LaravelInitCommand.php
+++ b/src/Commands/LaravelInitCommand.php
@@ -53,7 +53,7 @@ class LaravelInitCommand extends Command
         $this->runShellCommand("php artisan forms:install {$force}");
         $this->runShellCommand('php artisan deploy:install || true');
 
-        $this->runShellCommand("php artisan storage:link");
+        $this->runShellCommand('php artisan storage:link');
         $this->runShellCommand("php artisan migrate {$force}");
 
         $this->info('Packages installed successfully.');

--- a/src/Commands/LaravelInitCommand.php
+++ b/src/Commands/LaravelInitCommand.php
@@ -44,16 +44,16 @@ class LaravelInitCommand extends Command
         $this->runShellCommand("php artisan vendor:publish --tag=navigation-config {$force}");
         $this->runShellCommand("php artisan vendor:publish --tag=navigation-logo {$force}");
         $this->runShellCommand("php artisan vendor:publish --tag=forms-config {$force}");
-        $this->runShellCommand("php artisan vendor:publish --provider='Spatie\MediaLibrary\MediaLibraryServiceProvider' --tag=medialibrary-migrations");
+        $this->runShellCommand("php artisan vendor:publish --provider='Spatie\MediaLibrary\MediaLibraryServiceProvider' --tag=medialibrary-migrations {$force}");
 
         $this->runShellCommand("php artisan vite:install {$force}");
         $this->runShellCommand("php artisan tailwindcss:install {$force}");
         $this->runShellCommand('php artisan layout-wrapper:install');
         $this->runShellCommand('php artisan navigation:install');
         $this->runShellCommand("php artisan forms:install {$force}");
-        $this->runShellCommand('php artisan deploy:install');
+        $this->runShellCommand('php artisan deploy:install || true');
 
-        $this->runShellCommand("php artisan storage:link {$force}");
+        $this->runShellCommand("php artisan storage:link");
         $this->runShellCommand("php artisan migrate {$force}");
 
         $this->info('Packages installed successfully.');


### PR DESCRIPTION
Addresses bugs related to the installation process in the LaravelInitCommand.php file. Specifically, the changes include:

1. Adding the missing `$force` variable in the `vendor:publish` command for the `medialibrary-migrations` tag to ensure consistency.
2. Modifying the `deploy:install` command to include a fallback option (`|| true`) to handle any potential failures during installation.
3. Removing the unnecessary `$force` variable in the `storage:link` command for better execution.

These changes aim to enhance the reliability and robustness of the installation process by fixing bugs and improving error handling. This will result in a smoother and more stable installation experience for users.