### PR TITLE
Added support for the spatie/laravel-google-fonts package and published its configuration files using the vendor:publish command.

### DIFF
--- a/src/Commands/LaravelInitCommand.php
+++ b/src/Commands/LaravelInitCommand.php
@@ -24,7 +24,7 @@ class LaravelInitCommand extends Command
             'fuelviews/laravel-cpanel-auto-deploy' => '^0.0',
             'fuelviews/laravel-navigation' => '^0.0',
             'fuelviews/laravel-forms' => '^0.0',
-            "spatie/laravel-google-fonts" => "^1.4",
+            'spatie/laravel-google-fonts' => '^1.4',
             'spatie/laravel-medialibrary' => '^11.0',
         ];
 

--- a/src/Commands/LaravelInitCommand.php
+++ b/src/Commands/LaravelInitCommand.php
@@ -24,6 +24,7 @@ class LaravelInitCommand extends Command
             'fuelviews/laravel-cpanel-auto-deploy' => '^0.0',
             'fuelviews/laravel-navigation' => '^0.0',
             'fuelviews/laravel-forms' => '^0.0',
+            "spatie/laravel-google-fonts" => "^1.4",
             'spatie/laravel-medialibrary' => '^11.0',
         ];
 
@@ -45,6 +46,7 @@ class LaravelInitCommand extends Command
         $this->runShellCommand("php artisan vendor:publish --tag=navigation-logo {$force}");
         $this->runShellCommand("php artisan vendor:publish --tag=forms-config {$force}");
         $this->runShellCommand("php artisan vendor:publish --provider='Spatie\MediaLibrary\MediaLibraryServiceProvider' --tag=medialibrary-migrations {$force}");
+        $this->runShellCommand("php artisan vendor:publish --provider='Spatie\GoogleFonts\GoogleFontsServiceProvider' --tag='google-fonts-config' {$force}");
 
         $this->runShellCommand("php artisan vite:install {$force}");
         $this->runShellCommand("php artisan tailwindcss:install {$force}");


### PR DESCRIPTION
Adds support for the `spatie/laravel-google-fonts` package to our project. By including this package, we can easily manage and utilize Google Fonts in our Laravel application.

Additionally, this PR publishes the configuration files of the `spatie/laravel-google-fonts` package using the `vendor:publish` command. This ensures that the configuration files are easily accessible and modifiable as needed.

Overall, these changes enhance the functionality of our project by enabling the use of Google Fonts and providing a straightforward way to customize the configuration settings.